### PR TITLE
Add `NeedsEnv` requirement to the `provideCustomLayer` method

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1136,7 +1136,7 @@ sealed trait ZIO[-R, +E, +A] extends Serializable with ZIOPlatformSpecific[R, E,
    */
   final def provideCustomLayer[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[ZEnv, E1, R1]
-  )(implicit ev: ZEnv with R1 <:< R, tagged: Tag[R1]): ZIO[ZEnv, E1, A] =
+  )(implicit ev1: ZEnv with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): ZIO[ZEnv, E1, A] =
     provideSomeLayer[ZEnv](layer)
 
   /**

--- a/core/shared/src/main/scala/zio/ZManaged.scala
+++ b/core/shared/src/main/scala/zio/ZManaged.scala
@@ -691,7 +691,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends Serializable { self =>
    */
   def provideCustomLayer[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[ZEnv, E1, R1]
-  )(implicit ev: ZEnv with R1 <:< R, tagged: Tag[R1]): ZManaged[ZEnv, E1, A] =
+  )(implicit ev1: ZEnv with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): ZManaged[ZEnv, E1, A] =
     provideSomeLayer[ZEnv](layer)
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2227,7 +2227,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
    */
   def provideCustomLayer[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[ZEnv, E1, R1]
-  )(implicit ev: ZEnv with R1 <:< R, tagged: Tag[R1]): ZStream[ZEnv, E1, O] =
+  )(implicit ev1: ZEnv with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): ZStream[ZEnv, E1, O] =
     provideSomeLayer[ZEnv](layer)
 
   /**

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -272,7 +272,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    */
   def provideCustomLayer[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[TestEnvironment, E1, R1]
-  )(implicit ev: TestEnvironment with R1 <:< R, tagged: Tag[R1]): Spec[TestEnvironment, E1, T] =
+  )(implicit ev1: TestEnvironment with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): Spec[TestEnvironment, E1, T] =
     provideSomeLayer[TestEnvironment](layer)
 
   /**
@@ -290,7 +290,7 @@ final case class Spec[-R, +E, +T](caseValue: SpecCase[R, E, T, Spec[R, E, T]]) {
    */
   def provideCustomLayerShared[E1 >: E, R1 <: Has[_]](
     layer: ZLayer[TestEnvironment, E1, R1]
-  )(implicit ev: TestEnvironment with R1 <:< R, tagged: Tag[R1]): Spec[TestEnvironment, E1, T] =
+  )(implicit ev1: TestEnvironment with R1 <:< R, ev2: NeedsEnv[R], tagged: Tag[R1]): Spec[TestEnvironment, E1, T] =
     provideSomeLayerShared[TestEnvironment](layer)
 
   /**


### PR DESCRIPTION
At the moment, `provideCustomLayer` doesn't require `NeedsEnv` evidence, which leads to confusing cases.
```
val effect: UIO[Int] = UIO(1)
val layer: ULayer[Has[String]] = ZLayer.succeed("")

// won't compile as expected
val provided: UIO[Int] = effect.provideLayer(layer)

// won't compile as expected
val someProvided: URIO[ZEnv, Int] = effect.provideSomeLayer[ZEnv](layer)

// compiles without an error, even though this should behave the same way as a previous line
val customProvided: URIO[ZEnv, Int] = effect.provideCustomLayer(layer)
```

I found that `provideSomeLayer` and `NeedsEnv` requirement were introduced almost simultaneously (https://github.com/zio/zio/pull/2897 and https://github.com/zio/zio/pull/2909). I guess this is why there is a little inconsistency now.